### PR TITLE
Remove inspect on mix version

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -7,7 +7,7 @@ defmodule OpentelemetryTelemetry.MixProject do
 
     [
       app: app,
-      version: version(Keyword.fetch!(desc, :vsn)) |> IO.inspect(),
+      version: version(Keyword.fetch!(desc, :vsn)),
       description: to_string(Keyword.fetch!(desc, :description)),
       elixir: "~> 1.8",
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
Hi there!

This PR just removes an `IO.inspect/1` that is output on every mix command, when using this library as a dependency.

Thanks!