### PR TITLE
Improve ctx handling and improve API

### DIFF
--- a/lib/opentelemetry_telemetry.ex
+++ b/lib/opentelemetry_telemetry.ex
@@ -72,26 +72,49 @@ defmodule OpentelemetryTelemetry do
   span.
   """
 
+  @typedoc """
+  A span ctx for a telemetry-based span.
+  """
   @type telemetry_span_ctx() :: :opentelemetry.span_ctx()
+
+  @typedoc """
+  The parent span ctx for a telemetry-based span. This is what the current span ctx was
+  at the time of starting a telemetry-based span.
+  """
   @type parent_span_ctx() :: :opentelemetry.span_ctx()
 
   @type ctx_set() :: {parent_span_ctx(), telemetry_span_ctx()}
 
-  @doc """
-  Stores the passed `t:OpenTelemetry.span_ctx/0` for a given `tracer_id`.
+  @typedoc """
+  The name given to `OpenTelemetry.register_application_tracer/2`. For bridge libraries,
+  this is usually the name of the bridge library, e.g. `:opentelemetry_phoenix`
   """
+  @type tracer_id() :: atom()
+
+  @doc """
+  Start a telemetry-based span.
+  """
+  @spec start_telemetry_span(
+          tracer_id(),
+          :opentelemetry.span_name(),
+          :telemetry.event_metadata(),
+          OpenTelemetry.Tracer.start_opts()
+        ) :: OpenTelemetry.span_ctx()
   defdelegate start_telemetry_span(tracer_id, span_name, event_metadata, start_opts),
     to: :otel_telemetry
 
   @doc """
-  Convenience function `store_context/3` to use the current span context.
+  Set the current span ctx based on the tracer_id and telemetry event metadata.
   """
+  @spec set_current_telemetry_span(tracer_id(), :telemetry.event_metadata()) ::
+          OpenTelemetry.span_ctx()
   defdelegate set_current_telemetry_span(tracer_id, event_metadata), to: :otel_telemetry
 
   @doc """
-  Pops and returns a `t:OpenTelemetry.span_ctx/0` for a given `tracer_id`
-  from the span context store.
+  End a telemetry-based span based on the `tracer_id` and telemetry event metadata
+  and restore the current ctx to the span's parent ctx.
   """
+  @spec end_telemetry_span(tracer_id(), :telemetry.event_metadata()) :: :ok
   defdelegate end_telemetry_span(tracer_id, event_metadata), to: :otel_telemetry
 
   @doc false

--- a/lib/opentelemetry_telemetry.ex
+++ b/lib/opentelemetry_telemetry.ex
@@ -8,8 +8,17 @@ defmodule OpentelemetryTelemetry do
   `opentelemetry` does not automatically set current span context when ending
   another span. Since `telemetry` events are executed in separate handlers with
   no shared context, correlating individual events requires a mechanism to do so.
-  The provided `store_ctx/3`, `store_current_ctx/2`, and `pop_ctx/2` functions
-  give bridge library authors a mechanism for getting around this challenge.
+  Additionally, when ending telemetry-based spans, the user must set the correct
+  parent context back as the current context. This ensures sibling spans are
+  correctly correlated to the shared parent span.
+
+  This library provides helper functions to manage contexts automatically with
+  `start_telemetry_span/4`, `set_current_telemetry_span/2`, and `end_telemetry_span/2`
+  to give bridge library authors a mechanism for working with these challenges. Once
+  `start_telemetry_span/4` or `set_current_telemetry_span/2` are called, users
+  can use all of `OpenTelemetry` as normal. By providing the application tracer id
+  and the event's metadata, the provided span functions will identify and manage
+  span contexts automatically.
 
   ### Example Telemetry Event Handlers
 
@@ -18,22 +27,18 @@ defmodule OpentelemetryTelemetry do
               %{system_time: start_time},
               metadata,
               %{type: :start, tracer_id: tracer_id, span_name: name}) do
-      tracer = :opentelemetry.get_tracer(tracer_id)
-      OpentelemetryTelemetry.store_current_ctx(tracer_id, metadata)
       start_opts = %{start_time: start_time}
-      ctx = :otel_tracer.start_span(tracer, name, start_opts)
-      :otel_tracer.set_current_span(ctx)
-      ok
+      OpentelemetryTelemetry.start_telemetry_span(tracer_id, name, metadata, start_opts)
+      :ok
     end
 
     def handle_event(_event,
                 %{duration: duration},
                 metadata,
                 %{type: :stop, tracer_id: tracer_id}) do
-        :otel_tracer.set_attribute(:duration, duration)
-        :otel_tracer.end_span()
-        ctx = OpentelemetryTelemetry.pop_ctx(tracer_id, metadata)
-        :otel_tracer.set_current_span(ctx)
+        OpentelemetryTelemetry.set_current_telemetry_span(tracer_id, metadata)
+        OpenTelemetry.Tracer.set_attribute(:duration, duration)
+        OpentelemetryTelemetry.end_telemetry_span(tracer_id, metadata)
         :ok
     end
 
@@ -41,12 +46,11 @@ defmodule OpentelemetryTelemetry do
                 %{duration: duration},
                 %{kind: kind, reason: reason, stacktrace: stacktrace} = metadata,
                 %{type: :exception, tracer_id: tracer_id}) do
-        status = :opentelemetry.status(:error, to_string(reason, :utf8))
-        :otel_span.record_exception(:otel_tracer.current_span_ctx(), kind, reason, stacktrace, [{:duration, duration}])
-        :otel_tracer.set_status(status)
-        :otel_tracer.end_span()
-        ctx = OpentelemetryTelemetry.pop_ctx(tracer_id, metadata)
-        :otel_tracer.set_current_span(ctx)
+        ctx = OpentelemetryTelemetry.set_current_telemetry_span(tracer_id, metadata),
+        status = Opentelemetry.status(:error, to_string(reason, :utf8))
+        OpenTelemetry.Span.record_exception(ctx, kind, reason, stacktrace, [duration: duration])
+        OpenTelemetry.Tracer.set_status(status)
+        OpentelemetryTelemetry.end_telemetry_span(tracer_id, metadata)
         :ok
       end
     def handle_event(_event, _measurements, _metadata, _config), do: :ok
@@ -68,21 +72,27 @@ defmodule OpentelemetryTelemetry do
   span.
   """
 
+  @type telemetry_span_ctx() :: :opentelemetry.span_ctx()
+  @type parent_span_ctx() :: :opentelemetry.span_ctx()
+
+  @type ctx_set() :: {parent_span_ctx(), telemetry_span_ctx()}
+
   @doc """
   Stores the passed `t:OpenTelemetry.span_ctx/0` for a given `tracer_id`.
   """
-  defdelegate store_ctx(span_ctx, tracer_id, event_metadata), to: :otel_telemetry
+  defdelegate start_telemetry_span(tracer_id, span_name, event_metadata, start_opts),
+    to: :otel_telemetry
 
   @doc """
   Convenience function `store_context/3` to use the current span context.
   """
-  defdelegate store_current_ctx(tracer_id, event_metadata), to: :otel_telemetry
+  defdelegate set_current_telemetry_span(tracer_id, event_metadata), to: :otel_telemetry
 
   @doc """
   Pops and returns a `t:OpenTelemetry.span_ctx/0` for a given `tracer_id`
   from the span context store.
   """
-  defdelegate pop_ctx(tracer_id, event_metadata), to: :otel_telemetry
+  defdelegate end_telemetry_span(tracer_id, event_metadata), to: :otel_telemetry
 
   @doc false
   defdelegate trace_application(app), to: :otel_telemetry

--- a/src/otel_telemetry.erl
+++ b/src/otel_telemetry.erl
@@ -53,8 +53,8 @@ set_current_telemetry_span(TracerId, EventMetadata) ->
 
 -spec end_telemetry_span(atom(), telemetry:event_metadata()) -> ok.
 end_telemetry_span(TracerId, EventMetadata) ->
-    {ParentCtx, _Ctx} = pop_ctx(TracerId, EventMetadata),
-    otel_tracer:end_span(),
+    {ParentCtx, Ctx} = pop_ctx(TracerId, EventMetadata),
+    otel_span:end_span(Ctx),
     otel_tracer:set_current_span(ParentCtx),
     ok.
 

--- a/test/otel_telemetry_SUITE.erl
+++ b/test/otel_telemetry_SUITE.erl
@@ -44,6 +44,7 @@ telemetry_span_handling(_Config) ->
     SpanCtx1 = ?start_span(<<"span-1">>),
     ?set_current_span(SpanCtx1),
     _Result = test_app:handler(ok),
+    ?assertMatch(SpanCtx1, ?current_span_ctx),
     try test_app:handler(raise_exception) of
         _ -> ok
     catch


### PR DESCRIPTION
I realized this was inadvertently working in tests due to the calling order of functions. An assumption was created that the current span was the span we wanted to be working with and storing/popping what was actually the parent context.

This changes the behavior to track both the created span ctx and the parent span ctx linked together such that we always know that relationship. Additionally, the API was quite clunky after addressing that issue, so it has been changed to provide simpler abstractions for what bridge authors will be doing.