### PR TITLE
fix: Corrects the start time with the time offset

### DIFF
--- a/src/otel_telemetry.erl
+++ b/src/otel_telemetry.erl
@@ -143,7 +143,7 @@ handle_event(_Event,
              #{system_time := StartTime},
              Metadata,
              #{type := start, tracer_id := TracerId, span_name := Name}) ->
-    StartOpts = #{start_time => StartTime},
+    StartOpts = #{start_time => StartTime - erlang:time_offset()},
     _Ctx = start_telemetry_span(TracerId, Name, Metadata, StartOpts),
     ok;
 handle_event(_Event,


### PR DESCRIPTION
`telemetry:span/3` uses `erlang:system_time/0` for the start time, `opentelemetry:timestamp` uses `erlang:monotonic_time/0`, so we need to use the correction in the documentation (https://www.erlang.org/doc/man/erlang.html#system_time-0).

Fixes #13