### PR TITLE
fix: Removes explicit setting of start time and duration

### DIFF
--- a/src/otel_telemetry.erl
+++ b/src/otel_telemetry.erl
@@ -140,27 +140,25 @@ tracer_id_for_events(Prefix, [Suffix | _], AllEvents) ->
     Module.
 
 handle_event(_Event,
-             #{system_time := StartTime},
+             _Measurements,
              Metadata,
              #{type := start, tracer_id := TracerId, span_name := Name}) ->
-    StartOpts = #{start_time => StartTime},
-    _Ctx = start_telemetry_span(TracerId, Name, Metadata, StartOpts),
+    _Ctx = start_telemetry_span(TracerId, Name, Metadata, #{}),
     ok;
 handle_event(_Event,
-             #{duration := Duration},
+             _Measurements,
              Metadata,
              #{type := stop, tracer_id := TracerId}) ->
     Ctx = set_current_telemetry_span(TracerId, Metadata),
-    otel_span:set_attribute(Ctx, <<"duration">>, Duration),
     end_telemetry_span(TracerId, Metadata),
     ok;
 handle_event(_Event,
-             #{duration := Duration},
+             _Measurements,
              #{kind := Kind, reason := Reason, stacktrace := Stacktrace} = Metadata,
              #{type := exception, tracer_id := TracerId}) ->
     Ctx = set_current_telemetry_span(TracerId, Metadata),
     Status = opentelemetry:status(?OTEL_STATUS_ERROR, atom_to_binary(Reason, utf8)),
-    otel_span:record_exception(Ctx, Kind, Reason, Stacktrace, [{<<"duration">>, Duration}]),
+    otel_span:record_exception(Ctx, Kind, Reason, Stacktrace, []),
     otel_span:set_status(Ctx, Status),
     end_telemetry_span(TracerId, Metadata),
     ok;

--- a/test/otel_telemetry_SUITE.erl
+++ b/test/otel_telemetry_SUITE.erl
@@ -51,7 +51,6 @@ telemetry_span_handling(_Config) ->
         error:badarg -> ok
     end,
     ?assertMatch(SpanCtx1, ?current_span_ctx),
-    ?set_attribute(<<"duration">>, 1),
     ?end_span(),
     {_, Span3Parent} = successful_span_listener(<<"test_app_nested_span">>),
     {Span2, Span2Parent} = successful_span_listener(<<"test_app_handler">>),
@@ -65,8 +64,6 @@ telemetry_span_handling(_Config) ->
 successful_span_listener(Name) ->
     receive
         {span, #span{name=Name,attributes=Attributes,parent_span_id=ParentId,span_id=Id}} ->
-            Attr = maps:from_list(Attributes),
-            ?assert(maps:is_key(<<"duration">>, Attr)),
             {Id, ParentId}
     after
         5000 ->

--- a/test/otel_telemetry_SUITE.erl
+++ b/test/otel_telemetry_SUITE.erl
@@ -51,6 +51,7 @@ telemetry_span_handling(_Config) ->
         error:badarg -> ok
     end,
     ?assertMatch(SpanCtx1, ?current_span_ctx),
+    ?set_attribute(<<"attribute">>, 1),
     ?end_span(),
     {_, Span3Parent} = successful_span_listener(<<"test_app_nested_span">>),
     {Span2, Span2Parent} = successful_span_listener(<<"test_app_handler">>),


### PR DESCRIPTION
`telemetry:span/3` uses `erlang:system_time/0` for the start time, `opentelemetry:timestamp` uses `erlang:monotonic_time/0`, so we can avoid the problem altogether by using opentelemetry's internal timekeeping.

Fixes #13